### PR TITLE
Lazy-load non-critical SVG icons

### DIFF
--- a/efficient-64-bit-arithmetic.js
+++ b/efficient-64-bit-arithmetic.js
@@ -1,0 +1,6 @@
+// TODO: remove from `core-js@4` as withdrawn
+// https://gist.github.com/BrendanEich/4294d5c212a6d2254703
+require('../modules/esnext.math.iaddh');
+require('../modules/esnext.math.isubh');
+require('../modules/esnext.math.imulh');
+require('../modules/esnext.math.umulh');


### PR DESCRIPTION
Reduce initial bundle size and improve first-contentful-paint by lazy-loading non-critical SVG icons. Propose replacing static imports with a lightweight IconLoader that dynamically imports icons with a small placeholder, and update docs/tests to reflect the new usage.